### PR TITLE
Fix embedding argument names and added warning for translation

### DIFF
--- a/amulet/amulet.py
+++ b/amulet/amulet.py
@@ -126,6 +126,12 @@ def antiberta2(
             help="The path where the generated embeddings will be saved. The file extension should be .pt, .csv, or .tsv.",
         ),
     ],
+    cache_dir: Annotated[
+        str,
+        typer.Argument(
+            ..., help="Input sequences (H for heavy chain, L for light chain, HL for heavy and light concatenated)"
+        ),
+    ] = None,
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")
     ] = "sequence_vdj_aa",
@@ -162,8 +168,8 @@ def antiberta2(
     X = X.str.replace("  ", " ")
     sequences = X.values
 
-    tokenizer = RoFormerTokenizer.from_pretrained("alchemab/antiberta2")
-    model = RoFormerForMaskedLM.from_pretrained("alchemab/antiberta2")
+    tokenizer = RoFormerTokenizer.from_pretrained("alchemab/antiberta2", cache_dir=cache_dir)
+    model = RoFormerForMaskedLM.from_pretrained("alchemab/antiberta2", cache_dir=cache_dir)
     model = model.to(device)
     model_size = sum(p.numel() for p in model.parameters())
     logger.info("AntiBERTa2 loaded. Size: %s M", model_size / 1e6)
@@ -226,6 +232,12 @@ def esm2(
             help="The path where the generated embeddings will be saved. The file extension should be .pt, .csv, or .tsv.",
         ),
     ],
+    cache_dir: Annotated[
+        str,
+        typer.Argument(
+            ..., help="Input sequences (H for heavy chain, L for light chain, HL for heavy and light concatenated)"
+        ),
+    ] = None,
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")
     ] = "sequence_vdj_aa",
@@ -259,8 +271,8 @@ def esm2(
     X = X.apply(lambda a: a[:max_length])
     sequences = X.values
 
-    tokenizer = AutoTokenizer.from_pretrained("facebook/esm2_t33_650M_UR50D")
-    model = AutoModelForMaskedLM.from_pretrained("facebook/esm2_t33_650M_UR50D")
+    tokenizer = AutoTokenizer.from_pretrained("facebook/esm2_t33_650M_UR50D", cache_dir=cache_dir)
+    model = AutoModelForMaskedLM.from_pretrained("facebook/esm2_t33_650M_UR50D", cache_dir=cache_dir)
     model = model.to(device)
     model_size = sum(p.numel() for p in model.parameters())
     logger.info("ESM2 650M model size: %s M", round(model_size / 1e6, 2))

--- a/amulet/amulet.py
+++ b/amulet/amulet.py
@@ -50,6 +50,9 @@ def antiberty(
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")
     ] = "sequence_vdj_aa",
+    cell_id_col: Annotated[
+        str, typer.Option(help="The name of the column containing the single-cell barcode.")
+    ] = "cell_id",
     batch_size: Annotated[int, typer.Option(help="The batch size of sequences to embed.")] = 500,
 ):
     """
@@ -64,7 +67,7 @@ def antiberty(
 
     """
 
-    dat = process_airr(input_file_path, chain, sequence_col=sequence_col)
+    dat = process_airr(input_file_path, chain, sequence_col=sequence_col, cell_id_col=cell_id_col)
     logger.info("Embedding %s sequences using antiberty...", dat.shape[0])
     max_length = 512 - 2
     n_dat = dat.shape[0]
@@ -101,7 +104,7 @@ def antiberty(
     end_time = time.time()
     logger.info("Took %s seconds", round(end_time - start_time, 2))
 
-    save_embedding(dat, embeddings, output_file_path)
+    save_embedding(dat, embeddings, output_file_path, cell_id_col)
     logger.info("Saved embedding at %s", output_file_path)
 
 
@@ -126,6 +129,9 @@ def antiberta2(
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")
     ] = "sequence_vdj_aa",
+    cell_id_col: Annotated[
+        str, typer.Option(help="The name of the column containing the single-cell barcode.")
+    ] = "cell_id",
     batch_size: Annotated[int, typer.Option(help="The batch size of sequences to embed.")] = 128,
 ):
     """
@@ -140,7 +146,7 @@ def antiberta2(
         amulet antiberta2 tests/AIRR_rearrangement_translated_single-cell.tsv HL out.pt\n
     """
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    dat = process_airr(input_file_path, chain, sequence_col=sequence_col)
+    dat = process_airr(input_file_path, chain, sequence_col=sequence_col, cell_id_col=cell_id_col)
     max_length = 256
     n_dat = dat.shape[0]
 
@@ -198,7 +204,7 @@ def antiberta2(
     end_time = time.time()
     logger.info("Took %s seconds", round(end_time - start_time, 2))
 
-    save_embedding(dat, embeddings, output_file_path)
+    save_embedding(dat, embeddings, output_file_path, cell_id_col)
     logger.info("Saved embedding at %s", output_file_path)
 
 
@@ -223,6 +229,9 @@ def esm2(
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")
     ] = "sequence_vdj_aa",
+    cell_id_col: Annotated[
+        str, typer.Option(help="The name of the column containing the single-cell barcode.")
+    ] = "cell_id",
     batch_size: Annotated[int, typer.Option(help="The batch size of sequences to embed.")] = 50,
 ):
     """
@@ -237,7 +246,7 @@ def esm2(
     and the time taken for the embedding. The embeddings are saved at the location specified by `output_file_path`.
     """
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    dat = process_airr(input_file_path, chain, sequence_col=sequence_col)
+    dat = process_airr(input_file_path, chain, sequence_col=sequence_col, cell_id_col=cell_id_col)
     max_length = 512
     n_dat = dat.shape[0]
 
@@ -292,7 +301,7 @@ def esm2(
     end_time = time.time()
     logger.info("Took %s seconds", round(end_time - start_time, 2))
 
-    save_embedding(dat, embeddings, output_file_path)
+    save_embedding(dat, embeddings, output_file_path, cell_id_col)
     logger.info("Saved embedding at %s", output_file_path)
 
 
@@ -321,6 +330,9 @@ def custommodel(
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")
     ] = "sequence_vdj_aa",
+    cell_id_col: Annotated[
+        str, typer.Option(help="The name of the column containing the single-cell barcode.")
+    ] = "cell_id",
 ):
     """
     This function generates embeddings for a given dataset using a pretrained model. The function first checks if a CUDA device is available for PyTorch to use. It then loads the data from the input file and preprocesses it.
@@ -334,7 +346,7 @@ def custommodel(
 
     """
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    dat = process_airr(input_file_path, chain, sequence_col=sequence_col)
+    dat = process_airr(input_file_path, chain, sequence_col=sequence_col, cell_id_col=cell_id_col)
     X = dat.loc[:, sequence_col]
     X = X.apply(lambda a: a[:max_length])
     sequences = X.values
@@ -380,7 +392,7 @@ def custommodel(
     end_time = time.time()
     logger.info("Took %s seconds", round(end_time - start_time, 2))
 
-    save_embedding(dat, embeddings, output_file_path)
+    save_embedding(dat, embeddings, output_file_path, cell_id_col)
     logger.info("Saved embedding at %s", output_file_path)
 
 

--- a/amulet/amulet.py
+++ b/amulet/amulet.py
@@ -391,6 +391,13 @@ def translate_igblast(
     6. Saves the translated data into a new TSV file in the specified output directory.\n\n
     """
     data = pd.read_csv(input_file_path, sep="\t")
+
+    columns_reserved = ["sequence_aa", "sequence_alignment_aa", "sequence_vdj_aa"]
+    overlap = [col for col in data.columns if col in columns_reserved]
+    if len(overlap) > 0:
+        logger.warn("Existing amino acid columns (%s) will be overwritten.", ", ".join(overlap))
+        data = data.drop(overlap, axis=1)
+
     out_fasta = os.path.join(output_dir, os.path.splitext(os.path.basename(input_file_path))[0] + ".fasta")
     out_igblast = os.path.join(output_dir, os.path.splitext(os.path.basename(input_file_path))[0] + "_igblast.tsv")
     out_translated = os.path.join(

--- a/amulet/amulet.py
+++ b/amulet/amulet.py
@@ -41,7 +41,11 @@ def antiberty(
         ),
     ],
     output_file_path: Annotated[
-        str, typer.Argument(..., help="The path where the generated embeddings will be saved.")
+        str,
+        typer.Argument(
+            ...,
+            help="The path where the generated embeddings will be saved. The file extension should be .pt, .csv, or .tsv.",
+        ),
     ],
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")
@@ -113,7 +117,11 @@ def antiberta2(
         ),
     ],
     output_file_path: Annotated[
-        str, typer.Argument(..., help="The path where the generated embeddings will be saved.")
+        str,
+        typer.Argument(
+            ...,
+            help="The path where the generated embeddings will be saved. The file extension should be .pt, .csv, or .tsv.",
+        ),
     ],
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")
@@ -206,7 +214,11 @@ def esm2(
         ),
     ],
     output_file_path: Annotated[
-        str, typer.Argument(..., help="The path where the generated embeddings will be saved.")
+        str,
+        typer.Argument(
+            ...,
+            help="The path where the generated embeddings will be saved. The file extension should be .pt, .csv, or .tsv.",
+        ),
     ],
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")
@@ -297,7 +309,11 @@ def custommodel(
         ),
     ],
     output_file_path: Annotated[
-        str, typer.Argument(..., help="The path where the generated embeddings will be saved.")
+        str,
+        typer.Argument(
+            ...,
+            help="The path where the generated embeddings will be saved. The file extension should be .pt, .csv, or .tsv.",
+        ),
     ],
     embedding_dimension: Annotated[int, typer.Option(help="The dimension of the embedding layer.")] = 100,
     max_length: Annotated[int, typer.Option(help="The maximum length that the model can take.")] = 512,

--- a/amulet/amulet.py
+++ b/amulet/amulet.py
@@ -19,7 +19,13 @@ from transformers import (
 from typing_extensions import Annotated
 
 from amulet import __version__
-from amulet.utils import batch_loader, insert_space_every_other_except_cls, process_airr, save_embedding
+from amulet.utils import (
+    batch_loader,
+    check_output_file_type,
+    insert_space_every_other_except_cls,
+    process_airr,
+    save_embedding,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -66,7 +72,7 @@ def antiberty(
         amulet antiberty tests/AIRR_rearrangement_translated_single-cell.tsv HL out.pt
 
     """
-
+    out_format = check_output_file_type(output_file_path)
     dat = process_airr(input_file_path, chain, sequence_col=sequence_col, cell_id_col=cell_id_col)
     logger.info("Embedding %s sequences using antiberty...", dat.shape[0])
     max_length = 512 - 2
@@ -104,7 +110,7 @@ def antiberty(
     end_time = time.time()
     logger.info("Took %s seconds", round(end_time - start_time, 2))
 
-    save_embedding(dat, embeddings, output_file_path, cell_id_col)
+    save_embedding(dat, embeddings, output_file_path, out_format, cell_id_col)
     logger.info("Saved embedding at %s", output_file_path)
 
 
@@ -149,6 +155,7 @@ def antiberta2(
     Example Usage:\n
         amulet antiberta2 tests/AIRR_rearrangement_translated_single-cell.tsv HL out.pt\n
     """
+    out_format = check_output_file_type(output_file_path)
     device = "cuda" if torch.cuda.is_available() else "cpu"
     dat = process_airr(input_file_path, chain, sequence_col=sequence_col, cell_id_col=cell_id_col)
     max_length = 256
@@ -208,7 +215,7 @@ def antiberta2(
     end_time = time.time()
     logger.info("Took %s seconds", round(end_time - start_time, 2))
 
-    save_embedding(dat, embeddings, output_file_path, cell_id_col)
+    save_embedding(dat, embeddings, output_file_path, out_format, cell_id_col)
     logger.info("Saved embedding at %s", output_file_path)
 
 
@@ -253,6 +260,7 @@ def esm2(
     It prints the size of the model used for embedding, the batch number during the embedding process,
     and the time taken for the embedding. The embeddings are saved at the location specified by `output_file_path`.
     """
+    out_format = check_output_file_type(output_file_path)
     device = "cuda" if torch.cuda.is_available() else "cpu"
     dat = process_airr(input_file_path, chain, sequence_col=sequence_col, cell_id_col=cell_id_col)
     max_length = 512
@@ -309,7 +317,7 @@ def esm2(
     end_time = time.time()
     logger.info("Took %s seconds", round(end_time - start_time, 2))
 
-    save_embedding(dat, embeddings, output_file_path, cell_id_col)
+    save_embedding(dat, embeddings, output_file_path, out_format, cell_id_col)
     logger.info("Saved embedding at %s", output_file_path)
 
 
@@ -353,6 +361,7 @@ def custommodel(
         amulet custom_model <custom_model_path> tests/AIRR_rearrangement_translated_single-cell.tsv HL out.pt\n
 
     """
+    out_format = check_output_file_type(output_file_path)
     device = "cuda" if torch.cuda.is_available() else "cpu"
     dat = process_airr(input_file_path, chain, sequence_col=sequence_col, cell_id_col=cell_id_col)
     X = dat.loc[:, sequence_col]
@@ -400,7 +409,7 @@ def custommodel(
     end_time = time.time()
     logger.info("Took %s seconds", round(end_time - start_time, 2))
 
-    save_embedding(dat, embeddings, output_file_path, cell_id_col)
+    save_embedding(dat, embeddings, output_file_path, out_format, cell_id_col)
     logger.info("Saved embedding at %s", output_file_path)
 
 

--- a/amulet/amulet.py
+++ b/amulet/amulet.py
@@ -128,9 +128,7 @@ def antiberta2(
     ],
     cache_dir: Annotated[
         str,
-        typer.Argument(
-            ..., help="Input sequences (H for heavy chain, L for light chain, HL for heavy and light concatenated)"
-        ),
+        typer.Option(help="Cache dir for storing the pre-trained model weights."),
     ] = None,
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")
@@ -234,9 +232,7 @@ def esm2(
     ],
     cache_dir: Annotated[
         str,
-        typer.Argument(
-            ..., help="Input sequences (H for heavy chain, L for light chain, HL for heavy and light concatenated)"
-        ),
+        typer.Option(help="Cache dir for storing the pre-trained model weights."),
     ] = None,
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")

--- a/amulet/amulet.py
+++ b/amulet/amulet.py
@@ -31,7 +31,7 @@ stdout = Console()
 
 @app.command()
 def antiberty(
-    inpath: Annotated[
+    input_file_path: Annotated[
         str, typer.Argument(..., help="The path to the input data file. The data file should be in AIRR format.")
     ],
     chain: Annotated[
@@ -40,7 +40,9 @@ def antiberty(
             ..., help="Input sequences (H for heavy chain, L for light chain, HL for heavy and light concatenated)"
         ),
     ],
-    outpath: Annotated[str, typer.Argument(..., help="The path where the generated embeddings will be saved.")],
+    output_file_path: Annotated[
+        str, typer.Argument(..., help="The path where the generated embeddings will be saved.")
+    ],
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")
     ] = "sequence_vdj_aa",
@@ -58,7 +60,7 @@ def antiberty(
 
     """
 
-    dat = process_airr(inpath, chain, sequence_col=sequence_col)
+    dat = process_airr(input_file_path, chain, sequence_col=sequence_col)
     logger.info("Embedding %s sequences using antiberty...", dat.shape[0])
     max_length = 512 - 2
     n_dat = dat.shape[0]
@@ -95,13 +97,13 @@ def antiberty(
     end_time = time.time()
     logger.info("Took %s seconds", round(end_time - start_time, 2))
 
-    save_embedding(dat, embeddings, outpath)
-    logger.info("Saved embedding at %s", outpath)
+    save_embedding(dat, embeddings, output_file_path)
+    logger.info("Saved embedding at %s", output_file_path)
 
 
 @app.command()
 def antiberta2(
-    inpath: Annotated[
+    input_file_path: Annotated[
         str, typer.Argument(..., help="The path to the input data file. The data file should be in AIRR format.")
     ],
     chain: Annotated[
@@ -110,7 +112,9 @@ def antiberta2(
             ..., help="Input sequences (H for heavy chain, L for light chain, HL for heavy and light concatenated)"
         ),
     ],
-    outpath: Annotated[str, typer.Argument(..., help="The path where the generated embeddings will be saved.")],
+    output_file_path: Annotated[
+        str, typer.Argument(..., help="The path where the generated embeddings will be saved.")
+    ],
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")
     ] = "sequence_vdj_aa",
@@ -122,13 +126,13 @@ def antiberta2(
     Note:\n
     This function uses the ESM2 model for embedding. The maximum length of the sequences to be embedded is 512.
     It prints the size of the model used for embedding, the batch number during the embedding process,
-    and the time taken for the embedding. The embeddings are saved at the location specified by `outpath`.\n\n
+    and the time taken for the embedding. The embeddings are saved at the location specified by `output_file_path`.\n\n
 
     Example Usage:\n
         amulet antiberta2 tests/AIRR_rearrangement_translated_single-cell.tsv HL out.pt\n
     """
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    dat = process_airr(inpath, chain, sequence_col=sequence_col)
+    dat = process_airr(input_file_path, chain, sequence_col=sequence_col)
     max_length = 256
     n_dat = dat.shape[0]
 
@@ -186,13 +190,13 @@ def antiberta2(
     end_time = time.time()
     logger.info("Took %s seconds", round(end_time - start_time, 2))
 
-    save_embedding(dat, embeddings, outpath)
-    logger.info("Saved embedding at %s", outpath)
+    save_embedding(dat, embeddings, output_file_path)
+    logger.info("Saved embedding at %s", output_file_path)
 
 
 @app.command()
 def esm2(
-    inpath: Annotated[
+    input_file_path: Annotated[
         str, typer.Argument(..., help="The path to the input data file. The data file should be in AIRR format.")
     ],
     chain: Annotated[
@@ -201,7 +205,9 @@ def esm2(
             ..., help="Input sequences (H for heavy chain, L for light chain, HL for heavy and light concatenated)"
         ),
     ],
-    outpath: Annotated[str, typer.Argument(..., help="The path where the generated embeddings will be saved.")],
+    output_file_path: Annotated[
+        str, typer.Argument(..., help="The path where the generated embeddings will be saved.")
+    ],
     sequence_col: Annotated[
         str, typer.Option(help="The name of the column containing the amino acid sequences to embed.")
     ] = "sequence_vdj_aa",
@@ -216,10 +222,10 @@ def esm2(
     Note:\n
     This function uses the ESM2 model for embedding. The maximum length of the sequences to be embedded is 512.
     It prints the size of the model used for embedding, the batch number during the embedding process,
-    and the time taken for the embedding. The embeddings are saved at the location specified by `outpath`.
+    and the time taken for the embedding. The embeddings are saved at the location specified by `output_file_path`.
     """
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    dat = process_airr(inpath, chain, sequence_col=sequence_col)
+    dat = process_airr(input_file_path, chain, sequence_col=sequence_col)
     max_length = 512
     n_dat = dat.shape[0]
 
@@ -274,14 +280,14 @@ def esm2(
     end_time = time.time()
     logger.info("Took %s seconds", round(end_time - start_time, 2))
 
-    save_embedding(dat, embeddings, outpath)
-    logger.info("Saved embedding at %s", outpath)
+    save_embedding(dat, embeddings, output_file_path)
+    logger.info("Saved embedding at %s", output_file_path)
 
 
 @app.command()
 def custommodel(
     modelpath: Annotated[str, typer.Argument(..., help="The path to the pretrained model.")],
-    inpath: Annotated[
+    input_file_path: Annotated[
         str, typer.Argument(..., help="The path to the input data file. The data file should be in AIRR format.")
     ],
     chain: Annotated[
@@ -290,7 +296,9 @@ def custommodel(
             ..., help="Input sequences (H for heavy chain, L for light chain, HL for heavy and light concatenated)"
         ),
     ],
-    outpath: Annotated[str, typer.Argument(..., help="The path where the generated embeddings will be saved.")],
+    output_file_path: Annotated[
+        str, typer.Argument(..., help="The path where the generated embeddings will be saved.")
+    ],
     embedding_dimension: Annotated[int, typer.Option(help="The dimension of the embedding layer.")] = 100,
     max_length: Annotated[int, typer.Option(help="The maximum length that the model can take.")] = 512,
     batch_size: Annotated[int, typer.Option(help="The batch size of sequences to embed.")] = 50,
@@ -310,7 +318,7 @@ def custommodel(
 
     """
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    dat = process_airr(inpath, chain, sequence_col=sequence_col)
+    dat = process_airr(input_file_path, chain, sequence_col=sequence_col)
     X = dat.loc[:, sequence_col]
     X = X.apply(lambda a: a[:max_length])
     sequences = X.values
@@ -356,16 +364,16 @@ def custommodel(
     end_time = time.time()
     logger.info("Took %s seconds", round(end_time - start_time, 2))
 
-    save_embedding(dat, embeddings, outpath)
-    logger.info("Saved embedding at %s", outpath)
+    save_embedding(dat, embeddings, output_file_path)
+    logger.info("Saved embedding at %s", output_file_path)
 
 
 @app.command()
 def translate_igblast(
-    inpath: Annotated[
+    input_file_path: Annotated[
         str, typer.Argument(..., help="The path to the input data file. The data file should be in AIRR format.")
     ],
-    outdir: Annotated[str, typer.Argument(..., help="The directory where the generated embeddings will be saved.")],
+    output_dir: Annotated[str, typer.Argument(..., help="The directory where the generated embeddings will be saved.")],
     reference_dir: Annotated[str, typer.Argument(..., help="The directory to the igblast references.")],
 ):
     """
@@ -382,10 +390,12 @@ def translate_igblast(
     5. Removes gaps introduced by IgBlast from the sequence alignment.\n
     6. Saves the translated data into a new TSV file in the specified output directory.\n\n
     """
-    data = pd.read_csv(inpath, sep="\t")
-    out_fasta = os.path.join(outdir, os.path.splitext(os.path.basename(inpath))[0] + ".fasta")
-    out_igblast = os.path.join(outdir, os.path.splitext(os.path.basename(inpath))[0] + "_igblast.tsv")
-    out_translated = os.path.join(outdir, os.path.splitext(os.path.basename(inpath))[0] + "_translated.tsv")
+    data = pd.read_csv(input_file_path, sep="\t")
+    out_fasta = os.path.join(output_dir, os.path.splitext(os.path.basename(input_file_path))[0] + ".fasta")
+    out_igblast = os.path.join(output_dir, os.path.splitext(os.path.basename(input_file_path))[0] + "_igblast.tsv")
+    out_translated = os.path.join(
+        output_dir, os.path.splitext(os.path.basename(input_file_path))[0] + "_translated.tsv"
+    )
 
     start_time = time.time()
     logger.info("Converting AIRR table to FastA for IgBlast translation...")


### PR DESCRIPTION
- Modified input and output argument name to be more descriptive (Fixes #25)
- Added warning that translation will overwrite existing amino acid columns (Fixes #22)
- Added option to specify column name for single-cell barcode (Fixes #27)
- Added cache_dir option to antiBERTa2 and ESM2 (Fixes #28)